### PR TITLE
chore: check for multiple messages

### DIFF
--- a/github-actions-log-warning-checker.sh
+++ b/github-actions-log-warning-checker.sh
@@ -76,3 +76,4 @@ done < "$filename"
 
 # example of warning
 # Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
+# Warning: Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.


### PR DESCRIPTION
- Check for multiple messages
- Currently that includes:
  - Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
  - Warning: Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.