### PR TITLE
chore: check for multiple messages

### DIFF
--- a/github-actions-log-warning-checker.sh
+++ b/github-actions-log-warning-checker.sh
@@ -76,3 +76,4 @@ done < "$filename"
 
 # example of warning
 # Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
+# Warning: Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

--- a/github-actions-log-warning-checker.sh
+++ b/github-actions-log-warning-checker.sh
@@ -29,9 +29,7 @@ if [ -f "$output" ]; then
     mv $output "$output-$date.csv"
 fi
 
-
-
-echo "repo,workflow_name,workflow_url,found_in_latest_workflow_run" > $output
+echo "repo,workflow_name,workflow_url,finding,found_in_latest_workflow_run" > $output
 
 while read -r repofull ; 
 do
@@ -60,8 +58,19 @@ do
             run_output=$(gh run view $run_id -R $org/$repo)
             for warning_message in "${WARNING_LOG_MESSAGES[@]}"; do
                 if [[ $run_output == *"$warning_message"* ]]; then
+                    # determine if this is a deprecated workflow command or deprecated node12 action
+                    case $warning_message in
+                    "${WARNING_LOG_MESSAGES[0]}"*)
+                        FINDING="workflow command"
+                        ;;
+                    "${WARNING_LOG_MESSAGES[1]}"*)
+                        FINDING="node12 action"
+                        ;;
+                    esac
+                    # find if this was found in the latest run or not
                     latest=$([ "$i" -eq 0 ] && echo "yes" || echo "no")
-                    echo "$org/$repo,$workflow_name,$workflow_url,$latest" >> "$output"
+                    # print the results
+                    echo "$org/$repo,$workflow_name,$workflow_url,$FINDING,$latest" >> "$output"
                     break 2
                 fi
             done


### PR DESCRIPTION
- Check for multiple messages
- Currently that includes:
  - Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
  - Warning: Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.